### PR TITLE
Implement microphone permission check

### DIFF
--- a/Core/AudioManager.swift
+++ b/Core/AudioManager.swift
@@ -4,6 +4,24 @@ class AudioManager {
     private let engine = AVAudioEngine()
     var onLoudSound: ((Float) -> Void)?
 
+    func requestPermission(completion: @escaping (Bool) -> Void) {
+        let session = AVAudioSession.sharedInstance()
+        switch session.recordPermission {
+        case .granted:
+            completion(true)
+        case .denied:
+            completion(false)
+        case .undetermined:
+            session.requestRecordPermission { granted in
+                DispatchQueue.main.async {
+                    completion(granted)
+                }
+            }
+        @unknown default:
+            completion(false)
+        }
+    }
+
     func startMonitoring() {
         let input = engine.inputNode
         let format = input.outputFormat(forBus: 0)

--- a/Features/ChickenGameScene.swift
+++ b/Features/ChickenGameScene.swift
@@ -5,8 +5,9 @@ class ChickenGameScene: SKScene {
     var chicken: SKSpriteNode!
     let audioManager = AudioManager()
     private var isGameRunning = false
-    
+
     var completionHandler: ((_ didWin: Bool) -> Void)?
+    var permissionDeniedHandler: (() -> Void)?
     
     var lastTileX: CGFloat = 0
     var worldNode = SKNode()
@@ -29,16 +30,25 @@ class ChickenGameScene: SKScene {
     
     func startGame() {
         guard !isGameRunning else { return }
-        isGameRunning = true
-        chicken.physicsBody?.isDynamic = true
-        
-        audioManager.onLoudSound = { [weak self] db in
-            self?.handleSound(db: db)
+
+        audioManager.requestPermission { [weak self] granted in
+            guard let self = self else { return }
+            guard granted else {
+                self.permissionDeniedHandler?()
+                return
+            }
+
+            self.isGameRunning = true
+            self.chicken.physicsBody?.isDynamic = true
+
+            self.audioManager.onLoudSound = { [weak self] db in
+                self?.handleSound(db: db)
+            }
+            self.audioManager.startMonitoring()
+
+            // Небольшой стартовый импульс
+            self.handleSound(db: -15)
         }
-        audioManager.startMonitoring()
-        
-        // Небольшой стартовый импульс
-        handleSound(db: -15)
     }
     
     // MARK: - Анимация

--- a/Views/Chicken/ChickenGameView.swift
+++ b/Views/Chicken/ChickenGameView.swift
@@ -4,18 +4,20 @@ import SpriteKit
 struct ChickenGameView: UIViewRepresentable {
     let size: CGSize
     @Binding var gameState: ChickenGameFlowState
+    var onPermissionDenied: () -> Void = {}
     
     func makeUIView(context: Context) -> SKView {
         let skView = SKView()
         let scene = ChickenGameScene(size: size)
         scene.scaleMode = .resizeFill
-        
+
         // Связываем scene с нашим gameState
         scene.completionHandler = { didWin in
             DispatchQueue.main.async {
                 gameState = .gameOver(didWin: didWin)
             }
         }
+        scene.permissionDeniedHandler = onPermissionDenied
         
         skView.presentScene(scene)
         context.coordinator.scene = scene

--- a/Views/Chicken/ChickenGameWrapperView.swift
+++ b/Views/Chicken/ChickenGameWrapperView.swift
@@ -8,6 +8,7 @@ struct ChickenGameWrapperView: View {
     // MARK: – Game State
     @State private var gameState: ChickenGameFlowState = .ready
     @State private var gameID = UUID()
+    @State private var showMicAlert = false
     @Environment(\.dismiss) private var dismiss
 
     // MARK: – Theme Colors
@@ -19,7 +20,11 @@ struct ChickenGameWrapperView: View {
             GeometryReader { geometry in
                 ChickenGameView(
                     size: geometry.size,
-                    gameState: $gameState
+                    gameState: $gameState,
+                    onPermissionDenied: {
+                        showMicAlert = true
+                        gameState = .ready
+                    }
                 )
                 .id(gameID)
             }
@@ -72,6 +77,11 @@ struct ChickenGameWrapperView: View {
                 }
                 Spacer()
             }
+        }
+        .alert("Нет доступа к микрофону", isPresented: $showMicAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Для игры требуется доступ к микрофону. Разрешите его в настройках.")
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `requestPermission` helper in `AudioManager`
- request microphone permission before starting the chicken game
- expose permission denied handler through `ChickenGameScene` and `ChickenGameView`
- show an alert in `ChickenGameWrapperView` when access is denied

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68712bd9d85c8321b074232db717f093