### PR TITLE
Add GameManager calls on victory

### DIFF
--- a/Views/Bug/BugGameWrapperView.swift
+++ b/Views/Bug/BugGameWrapperView.swift
@@ -8,6 +8,7 @@ struct BugGameWrapperView: View {
     // MARK: – Game State
     @State private var gameState: BugGameFlowState = .ready
     @State private var gameID = UUID()
+    @EnvironmentObject private var gameManager: GameManager
     @Environment(\.dismiss) private var dismiss
 
     // MARK: – Theme Colors
@@ -34,15 +35,16 @@ struct BugGameWrapperView: View {
 
                 case .gameOver(let didWin):
                     if didWin {
-                        BugVictoryView(
-                            lightBlue: lightBlue,
-                            darkGreen: darkGreen
-                        )
-                        .onAppear {
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                                dismiss()
-                            }
+                    BugVictoryView(
+                        lightBlue: lightBlue,
+                        darkGreen: darkGreen
+                    )
+                    .onAppear {
+                        gameManager.complete(level: 4)
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                            dismiss()
                         }
+                    }
                     } else {
                         BugGameOverView(
                             lightBlue: lightBlue,
@@ -205,5 +207,6 @@ struct BugGameOverView: View {
 
 #Preview {
     BugGameWrapperView()
+        .environmentObject(GameManager())
 }
 

--- a/Views/Chicken/ChickenGameWrapperView.swift
+++ b/Views/Chicken/ChickenGameWrapperView.swift
@@ -8,6 +8,7 @@ struct ChickenGameWrapperView: View {
     // MARK: – Game State
     @State private var gameState: ChickenGameFlowState = .ready
     @State private var gameID = UUID()
+    @EnvironmentObject private var gameManager: GameManager
     @Environment(\.dismiss) private var dismiss
 
     // MARK: – Theme Colors
@@ -51,15 +52,16 @@ struct ChickenGameWrapperView: View {
 
                 case .gameOver(let didWin):
                     if didWin {
-                        ChickenVictoryView(
-                            lightBlue: lightBlue,
-                            darkGreen: darkGreen
-                        )
-                        .onAppear {
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                                dismiss()
-                            }
+                    ChickenVictoryView(
+                        lightBlue: lightBlue,
+                        darkGreen: darkGreen
+                    )
+                    .onAppear {
+                        gameManager.complete(level: 3)
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                            dismiss()
                         }
+                    }
                     } else {
                         ChickenGameOverView(
                             lightBlue: lightBlue,
@@ -213,5 +215,6 @@ struct ChickenGameOverView: View {
 
 #Preview {
     ChickenGameWrapperView()
+        .environmentObject(GameManager())
 }
 


### PR DESCRIPTION
## Summary
- inject `GameManager` as an environment object in ChickenGameWrapperView and BugGameWrapperView
- mark levels 3 and 4 as completed when the player wins
- update previews to provide a `GameManager`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68712b41dfd08321bc7995aa614e66a6