### PR TITLE
Fix chicken game visual issues

### DIFF
--- a/Core/AudioManager.swift
+++ b/Core/AudioManager.swift
@@ -20,7 +20,7 @@ class AudioManager {
             let avg = sqrt(sum / Float(buffer.frameLength))
             let db = 20 * log10(avg)
 
-            if db > -50 {
+            if db > -30 {
                 DispatchQueue.main.async {
                     self?.onLoudSound?(db)
                 }

--- a/Features/ChickenGameScene.swift
+++ b/Features/ChickenGameScene.swift
@@ -7,6 +7,7 @@ class ChickenGameScene: SKScene {
     private var isGameRunning = false
     
     var completionHandler: ((_ didWin: Bool) -> Void)?
+    var stepUpdateHandler: ((Int) -> Void)?
     
     var lastTileX: CGFloat = 0
     var worldNode = SKNode()
@@ -91,6 +92,7 @@ class ChickenGameScene: SKScene {
         
         stepCount += 1
         scoreLabel.text = "Шагов: \(stepCount) / \(targetSteps)"
+        stepUpdateHandler?(stepCount)
         
         if stepCount >= targetSteps {
             triggerVictory()
@@ -142,9 +144,11 @@ class ChickenGameScene: SKScene {
     
     func setupChicken(isDynamic: Bool) {
         chicken = SKSpriteNode(imageNamed: "chicken_1")
-        chicken.position = CGPoint(x: frame.minX + 100, y: frame.midY - 80)
+        chicken.setScale(0.2)
+        let tileHeight: CGFloat = 20
+        let startY = frame.midY - 100 + tileHeight / 2 + chicken.size.height / 2
+        chicken.position = CGPoint(x: frame.minX + 100, y: startY)
         chicken.zPosition = 1
-        chicken.setScale(0.08)
         
         chicken.physicsBody = SKPhysicsBody(rectangleOf: chicken.size)
         chicken.physicsBody?.isDynamic = isDynamic
@@ -161,7 +165,7 @@ class ChickenGameScene: SKScene {
     func setupScoreLabel() {
         scoreLabel = SKLabelNode(fontNamed: "ArialRoundedMTBold")
         scoreLabel.fontSize = 32
-        scoreLabel.fontColor = .black
+        scoreLabel.fontColor = .white
         scoreLabel.position = CGPoint(x: frame.midX, y: frame.maxY - 80)
         scoreLabel.zPosition = 10
         scoreLabel.text = "Шагов: 0 / \(targetSteps)"

--- a/Views/Chicken/ChickenGameView.swift
+++ b/Views/Chicken/ChickenGameView.swift
@@ -4,11 +4,17 @@ import SpriteKit
 struct ChickenGameView: UIViewRepresentable {
     let size: CGSize
     @Binding var gameState: ChickenGameFlowState
+    @Binding var stepCount: Int
     
     func makeUIView(context: Context) -> SKView {
         let skView = SKView()
         let scene = ChickenGameScene(size: size)
         scene.scaleMode = .resizeFill
+        scene.stepUpdateHandler = { count in
+            DispatchQueue.main.async {
+                stepCount = count
+            }
+        }
         
         // Связываем scene с нашим gameState
         scene.completionHandler = { didWin in

--- a/Views/Chicken/ChickenGameWrapperView.swift
+++ b/Views/Chicken/ChickenGameWrapperView.swift
@@ -8,6 +8,7 @@ struct ChickenGameWrapperView: View {
     // MARK: – Game State
     @State private var gameState: ChickenGameFlowState = .ready
     @State private var gameID = UUID()
+    @State private var stepCount = 0
     @Environment(\.dismiss) private var dismiss
 
     // MARK: – Theme Colors
@@ -16,10 +17,15 @@ struct ChickenGameWrapperView: View {
 
     var body: some View {
         ZStack {
+            Image("bg_hills_sky")
+                .resizable()
+                .scaledToFill()
+                .ignoresSafeArea()
             GeometryReader { geometry in
                 ChickenGameView(
                     size: geometry.size,
-                    gameState: $gameState
+                    gameState: $gameState,
+                    stepCount: $stepCount
                 )
                 .id(gameID)
             }
@@ -37,7 +43,13 @@ struct ChickenGameWrapperView: View {
 
                 case .playing:
                     HStack {
+                        Text("Шагов: \(stepCount) / 100")
+                            .font(.title3)
+                            .foregroundColor(.white)
+                            .padding(.leading)
+
                         Spacer()
+
                         Button {
                             dismiss()
                         } label: {


### PR DESCRIPTION
## Summary
- show game background in `ChickenGameWrapperView`
- pass step count updates from the SpriteKit scene to SwiftUI
- display step count overlay while playing
- enlarge chicken and position on starting platform
- reduce microphone sensitivity
- make score label visible

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687133f9edf08321856871147c612df8